### PR TITLE
Product tab selection color scheme issue fixed 

### DIFF
--- a/src/assets/scss/components/productList.scss
+++ b/src/assets/scss/components/productList.scss
@@ -41,7 +41,7 @@
   }
 
   &-selected {
-    background-color: $primary;
+    background-color: $eos-cerulean-500;
     color: $eos-white;
     transform: scale(1.03);
 


### PR DESCRIPTION
**Issue Number**


#89 

**Changes made**

Used eos-cerulean-500 instead of eos-cerulean-900 for Product selection tabs when they are selected so that brand logo doesn't disappear on selection.

**Before changes**

![Screenshot from 2021-09-16 20-06-04](https://user-images.githubusercontent.com/79930697/133746523-057f5aab-dd86-4b76-bf01-c3539ee8c1b0.png)

**After Changes**

![Screenshot from 2021-09-17 13-31-59](https://user-images.githubusercontent.com/79930697/133747376-2e8c1bc3-5759-4cc8-8421-6037630bda51.png)


**Checklist**


- [x] My code follows the code style of this project.
- [  ] My change requires a change to the documentation.
- [  ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**

Preview: Deploy preview link here with the appropriate route

<!-- Please add deployed link to here text >
