### PR TITLE
Removing pagination when not needed as mentioned in issue #96

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -30,56 +30,60 @@ const Pagination = (props) => {
     }
   }, [storyCount])
 
-  return (
-    <div className='pagination'>
-      <span
-        className={`btn btn-pagination ${
-          currNumber <= 1 ? 'btn-pagination-disabled' : ''
-        }`}
-        onClick={() => {
-          if (pages.find((page) => page === currNumber - 1)) {
-            setCurrNumber((currNumber) => currNumber - 1)
-            getPage(currNumber - 1)
-          }
-        }}
-      >
-        <EOS_KEYBOARD_ARROW_LEFT className='eos-icons eos-18' />
-        {`Prev`}
-      </span>
-      <div className='btn btn-pagination'>
-        {pages
-          ? pages.map((ele, key) => {
-              return (
-                <span
-                  className={`number ${currNumber === ele ? 'selected' : ''}`}
-                  onClick={() => {
-                    setCurrNumber(ele)
-                    getPage(ele)
-                  }}
-                  key={key}
-                >
-                  {ele}
-                </span>
-              )
-            })
-          : ''}
+  if (storyCount > 5) {
+    return (
+      <div className='pagination'>
+        <span
+          className={`btn btn-pagination ${
+            currNumber <= 1 ? 'btn-pagination-disabled' : ''
+          }`}
+          onClick={() => {
+            if (pages.find((page) => page === currNumber - 1)) {
+              setCurrNumber((currNumber) => currNumber - 1)
+              getPage(currNumber - 1)
+            }
+          }}
+        >
+          <EOS_KEYBOARD_ARROW_LEFT className='eos-icons eos-18' />
+          {`Prev`}
+        </span>
+        <div className='btn btn-pagination'>
+          {pages
+            ? pages.map((ele, key) => {
+                return (
+                  <span
+                    className={`number ${currNumber === ele ? 'selected' : ''}`}
+                    onClick={() => {
+                      setCurrNumber(ele)
+                      getPage(ele)
+                    }}
+                    key={key}
+                  >
+                    {ele}
+                  </span>
+                )
+              })
+            : ''}
+        </div>
+        <span
+          className={`btn btn-pagination ${
+            currNumber >= pages?.length ? 'btn-pagination-disabled' : ''
+          }`}
+          onClick={() => {
+            if (pages.find((page) => page === currNumber + 1)) {
+              setCurrNumber((currNumber) => currNumber + 1)
+              getPage(currNumber + 1)
+            }
+          }}
+        >
+          {`Next`}
+          <EOS_KEYBOARD_ARROW_RIGHT className='eos-icons eos-18' />
+        </span>
       </div>
-      <span
-        className={`btn btn-pagination ${
-          currNumber >= pages?.length ? 'btn-pagination-disabled' : ''
-        }`}
-        onClick={() => {
-          if (pages.find((page) => page === currNumber + 1)) {
-            setCurrNumber((currNumber) => currNumber + 1)
-            getPage(currNumber + 1)
-          }
-        }}
-      >
-        {`Next`}
-        <EOS_KEYBOARD_ARROW_RIGHT className='eos-icons eos-18' />
-      </span>
-    </div>
-  )
+    )
+  } else {
+    return null
+  }
 }
 
 export default Pagination

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -30,8 +30,8 @@ const Pagination = (props) => {
     }
   }, [storyCount])
 
-  if (storyCount > 5) {
-    return (
+  return (
+    storyCount > 5 && (
       <div className='pagination'>
         <span
           className={`btn btn-pagination ${
@@ -81,9 +81,7 @@ const Pagination = (props) => {
         </span>
       </div>
     )
-  } else {
-    return null
-  }
+  )
 }
 
 export default Pagination


### PR DESCRIPTION

fixes Issue #96 

<!-- Please Mention the issue number as ISSUE #(Issue Number)
Example:
fixes #1
-->
Removes unnecessary pagination toggle when there are less than 5 stories.

*Example Pagination toggle*
![image](https://user-images.githubusercontent.com/55888723/145686441-eae87fb7-2d53-472d-8e16-ec76d811f9b4.png)


<!-- Add any other context or screenshots about the feature request here. -->




<!-- Please add deployed link to here text >
