### PR TITLE
Added "Created At" field in user-story

### DIFF
--- a/src/components/StoriesList.js
+++ b/src/components/StoriesList.js
@@ -96,16 +96,6 @@ const StoriesList = (props) => {
                   <small>Category</small>
                   <span className='category-text'>{story.Category}</span>
                 </div>
-                <div className='flex flex-column story-subcontent'>
-                  <small>Created At</small>
-                  <span className='category-text'>
-                    {new Date(story.createdAt).toLocaleDateString(undefined, {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric'
-                    })}
-                  </span>
-                </div>
                 <div className='flex flex-column s-metas'>
                   <span className='story-meta'>
                     <EOS_ATTACHMENT className='eos-icons' />

--- a/src/components/StoriesList.js
+++ b/src/components/StoriesList.js
@@ -96,6 +96,16 @@ const StoriesList = (props) => {
                   <small>Category</small>
                   <span className='category-text'>{story.Category}</span>
                 </div>
+                <div className='flex flex-column story-subcontent'>
+                  <small>Created At</small>
+                  <span className='category-text'>
+                    {new Date(story.createdAt).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric'
+                    })}
+                  </span>
+                </div>
                 <div className='flex flex-column s-metas'>
                   <span className='story-meta'>
                     <EOS_ATTACHMENT className='eos-icons' />

--- a/src/pages/Story.js
+++ b/src/pages/Story.js
@@ -134,7 +134,18 @@ const Story = (props) => {
                     fill='#42779B'
                   />
                 </svg>
-                <h2>{story.Title}</h2>
+                <span>
+                  <h2 style={{ marginBlockEnd: '0px' }}>{story.Title}</h2>
+                  <br />
+                  <h4 style={{ marginBlockStart: '0px' }}>
+                    Created At:{' '}
+                    {new Date(story.createdAt).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric'
+                    })}
+                  </h4>
+                </span>
                 <div className='author-information'>
                   <h4>
                     By:{' '}
@@ -177,14 +188,6 @@ const Story = (props) => {
                       </>
                     }
                   </div>
-                  <h4>
-                    Created At:{' '}
-                    {new Date(story.createdAt).toLocaleDateString(undefined, {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric'
-                    })}
-                  </h4>
                 </div>
               </div>
 

--- a/src/pages/Story.js
+++ b/src/pages/Story.js
@@ -177,6 +177,14 @@ const Story = (props) => {
                       </>
                     }
                   </div>
+                  <h4>
+                    Created At:{' '}
+                    {new Date(story.createdAt).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric'
+                    })}
+                  </h4>
                 </div>
               </div>
 

--- a/src/services/user_story.js
+++ b/src/services/user_story.js
@@ -86,6 +86,7 @@ const userStory = {
                   username
                 }
                 Category
+                createdAt
               }
             }
             `
@@ -111,6 +112,7 @@ const userStory = {
             id
             url
           }
+          createdAt
         }
       }
       ${BASIC_STORY_INFO_FRAGMENT}


### PR DESCRIPTION
**Issue Number**

fixes #111 

<!-- Please Mention the issue number as ISSUE #(Issue Number)
Example:
fixes #1
-->

**Describe the changes you've made**

I have added the ```createdAt``` field in the GraphQL API call and this returns the date when a story was created. The date is then displayed in the list of stories and in the story description, as **Created At** field.

**Describe if there is any unusual behavior (Any Warning) of your code(Write `NA` if there isn't)**

<!-- A clear and concise description of it. -->
NA

**Additional context (OPTIONAL)**

<!-- Add any other context or screenshots about the feature request here. -->
NA

**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**

In the story list:
![image](https://user-images.githubusercontent.com/75155230/148754703-99b51351-4d67-4a0c-8f05-c1d9deb20474.png)

In the story description:
![image](https://user-images.githubusercontent.com/75155230/148754808-e5bc7017-940b-4ab9-8edb-8d4695b3935d.png)


