### PR TITLE
Fix #88: Added URL to convert mentions into links

### DIFF
--- a/src/components/CommentForm.js
+++ b/src/components/CommentForm.js
@@ -69,6 +69,7 @@ const CommentForm = (props) => {
               trigger='@'
               data={users}
               displayTransform={displayTransform}
+              markup={`<a class='mentions' href=${window.location.origin}/profile/__id__>@__display__</a>`}
             />
           </MentionsInput>
           <div className='file-input'>


### PR DESCRIPTION
**Issue Number**

fixes #88 

**Describe the changes you've made**

I have added a URL template in the `markup` attribute of mentions. This helps to generate a proper URL where the user is redirected upon clicking on the corresponding mention.

**Describe if there is any unusual behavior (Any Warning) of your code(Write `NA` if there isn't)**

`NA`

**Additional context (OPTIONAL)**

https://user-images.githubusercontent.com/75155230/154075852-40fe06e5-7b31-427a-8895-e672860b15f0.mp4



**Test plan (OPTIONAL)**

A good test plan should give instructions that someone else can easily follow.

`NA`

**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**

Preview: Deploy preview link here with the appropriate route

`NA`
