### PR TITLE
Fix #147: All stories are displayed by default

### DIFF
--- a/src/components/Stories.js
+++ b/src/components/Stories.js
@@ -12,13 +12,13 @@ import userStory from '../services/user_story'
 import ProductList from './ProductList'
 
 const Stories = ({ authorId, followerId }) => {
-  const [currentStateSelected, selectState] = useState('Under consideration')
+  const [currentStateSelected, selectState] = useState('All')
 
   const [page, setPage] = useState(1)
 
   const statusOptions = useMemo(() => [], [])
 
-  const [status, setStatus] = useState('Under consideration')
+  const [status, setStatus] = useState('All')
 
   const [sort, setSort] = useState('Most Voted')
 

--- a/src/services/user_story.js
+++ b/src/services/user_story.js
@@ -45,9 +45,13 @@ const userStory = {
               userStories(sort: "createdAt:desc", limit: 5, start: ${
                 (page - 1) * 5
               }, where: {
-                  user_story_status : {
-                    Status: "${currentStateSelected}"
-                  },
+                  ${
+                    currentStateSelected !== 'All'
+                      ? `user_story_status : {
+                      Status: "${currentStateSelected}"
+                    },`
+                      : ''
+                  }
                   author: {
                     ${authorId}
                     username_contains: "${authorQuery}"

--- a/src/utils/Lists.js
+++ b/src/utils/Lists.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  EOS_ALL_INCLUSIVE,
   EOS_SCHEDULE,
   EOS_CHECK_CIRCLE,
   EOS_MODE_EDIT,
@@ -10,6 +11,10 @@ import {
 
 const Lists = {
   stateList: [
+    {
+      icon: <EOS_ALL_INCLUSIVE className='eos-icons' />,
+      status: 'All'
+    },
     {
       icon: <EOS_SCHEDULE className='eos-icons' />,
       status: 'Under consideration'


### PR DESCRIPTION
**Issue Number**

fixes #147 

**Describe the changes you've made**

I have added a new element in the `StatusList` i.e `All` to represent the status of displaying all the stories. I have also used ternary operator to dynamically modify the service which is made to fetch the stories. This will help to fetch all the stories, irrespective of the status.

**Describe if there is any unusual behavior (Any Warning) of your code(Write `NA` if there isn't)**

NA

**Additional context (OPTIONAL)**

NA

**Test plan (OPTIONAL)**

NA

**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**


https://user-images.githubusercontent.com/75155230/156059503-3b015bd3-a60e-457c-b9cd-a1d2c913821f.mp4


