### PR TITLE
Dismiss modal on backdrop click

### DIFF
--- a/src/assets/scss/pages/home.scss
+++ b/src/assets/scss/pages/home.scss
@@ -26,9 +26,9 @@ $subheader-font-size: 18px;
 }
 
 .options-bar {
-  justify-content: center;
   background-color: $eos-white;
   border-radius: 10px;
+  justify-content: center;
   padding: 8px;
 }
 

--- a/src/assets/scss/pages/story.scss
+++ b/src/assets/scss/pages/story.scss
@@ -25,7 +25,7 @@
   }
 
   &-page {
-    height: 100vh;
+    height: 100%;
     position: relative;
   }
 

--- a/src/components/LanguageDropdown.js
+++ b/src/components/LanguageDropdown.js
@@ -31,11 +31,11 @@ const LanguageDropdown = (props) => {
         onClick={handleButtonClick}
       >
         {dropdownState ? (
-          <EOS_KEYBOARD_ARROW_UP className='eos-icons' />
+          <EOS_KEYBOARD_ARROW_UP />
         ) : (
-          <EOS_KEYBOARD_ARROW_DOWN className='eos-icons' />
+          <EOS_KEYBOARD_ARROW_DOWN />
         )}
-        &nbsp; <div className='curr'> Language </div>
+        &nbsp; <div> Language </div>
       </Button>
       {dropdownState ? (
         <div className='dropdown'>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -39,7 +39,10 @@ const Modal = (props) => {
       {active ? (
         <>
           <div className='modal' onClick={props.handleClose}>
-            <div className='modal-card-vote'>
+            <div
+              className='modal-card-vote'
+              onClick={(e) => e.stopPropagation()}
+            >
               <div className='modal-content'>
                 <span className='close-icon' onClick={props.handleClose}>
                   &times;

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -38,7 +38,7 @@ const Modal = (props) => {
       )}
       {active ? (
         <>
-          <div className='modal'>
+          <div className='modal' onClick={props.handleClose}>
             <div className='modal-card-vote'>
               <div className='modal-content'>
                 <span className='close-icon' onClick={props.handleClose}>


### PR DESCRIPTION
**Issue Number**

fixes #197 

<!-- Please Mention the issue number as ISSUE #(Issue Number)
Example:
fixes #1
-->

**Describe the changes you've made**

<!-- A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know! -->
Added `onClick` listener on the modal backdrop. But, since the `div` that holds the actual modal is the child of the whole modal container, clicking on the modal would also dismiss the modal, this is an undesired behavior and to avoid such behaviors, I've prevented event bubbling from the child `div` to the outer `div`(backdrop) by using `e.stopPropagation()`

**Describe if there is any unusual behavior (Any Warning) of your code(Write `NA` if there isn't)**

<!-- A clear and concise description of it. -->

**Additional context (OPTIONAL)**

<!-- Add any other context or screenshots about the feature request here. -->

**Test plan (OPTIONAL)**

A good test plan should give instructions that someone else can easily follow.

<!-- How someone can test your code? -->

**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**

Preview: Deploy preview link here with the appropriate route

<!-- Please add deployed link to here text >
