### PR TITLE
Fix #208: Added profile picture in comments

### DIFF
--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -110,6 +110,8 @@ const Comments = (props) => {
     }
   }
 
+  console.log({ comments })
+
   return (
     <div className='comments-wrapper'>
       {state.auth && (
@@ -134,7 +136,11 @@ const Comments = (props) => {
               <div className='user-avatar'>
                 <img
                   className='avatar'
-                  src={`https://avatars.dicebear.com/api/jdenticon/${data.user.username}.svg`}
+                  src={
+                    data.user.profilePicture && data.user.profilePicture.url
+                      ? data.user.profilePicture.url
+                      : `https://avatars.dicebear.com/api/jdenticon/${data.user.username}.svg`
+                  }
                   alt='Default User Avatar'
                 ></img>
               </div>
@@ -211,7 +217,12 @@ const Comments = (props) => {
                       <div className='user-avatar'>
                         <img
                           className='avatar'
-                          src={`https://avatars.dicebear.com/api/jdenticon/${reply.user.username}.svg`}
+                          src={
+                            reply.user.profilePicture &&
+                            reply.user.profilePicture.url
+                              ? reply.user.profilePicture.url
+                              : `https://avatars.dicebear.com/api/jdenticon/${reply.user.username}.svg`
+                          }
                           alt='Default User Avatar'
                         ></img>
                       </div>

--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -110,8 +110,6 @@ const Comments = (props) => {
     }
   }
 
-  console.log({ comments })
-
   return (
     <div className='comments-wrapper'>
       {state.auth && (

--- a/src/services/user_story.js
+++ b/src/services/user_story.js
@@ -352,6 +352,9 @@ const userStory = {
             user {
               id
               username
+              profilePicture{
+                url
+              }
             }
             createdAt
             attachment {
@@ -364,6 +367,9 @@ const userStory = {
               user {
                 id
                 username
+                profilePicture{
+                  url
+                }
               }
               attachment {
                 id


### PR DESCRIPTION
**Issue Number**

fixes #208 

<!-- Please Mention the issue number as ISSUE #(Issue Number)
Example:
fixes #1
-->

**Describe the changes you've made**

I have modified the GraphQL Query to fetch comments such that they will also fetch the profile picture of the user. I have then added the URL in the response to be rendered in the image.

**Describe if there is any unusual behavior (Any Warning) of your code(Write `NA` if there isn't)**

NA

**Additional context (OPTIONAL)**

NA

**Test plan (OPTIONAL)**

NA



**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**

![image](https://user-images.githubusercontent.com/75155230/167398783-2baecae4-f945-4657-8b78-b87e9238393a.png)
