### PR TITLE
Fix #269: Added label for Manager role

### DIFF
--- a/src/assets/scss/components/index.scss
+++ b/src/assets/scss/components/index.scss
@@ -28,3 +28,4 @@
 @import 'switch.scss';
 @import 'SimilarStories.scss';
 @import 'statusContainer.scss';
+@import 'tag.scss';

--- a/src/assets/scss/components/tag.scss
+++ b/src/assets/scss/components/tag.scss
@@ -1,0 +1,11 @@
+.tag {
+  background-color: $dark-gray-transparent;
+  border-radius: 16px;
+  color: $eos-white;
+  font-size: $font-size-small;
+  font-weight: $font-weight-600;
+  margin: auto;
+  margin-right: 50%;
+  padding: 5px 10px;
+  width: fit-content;
+}

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+function Tag(props) {
+  return <div className='tag'>{props.content}</div>
+}
+
+export default Tag

--- a/src/components/UserProfile.jsx
+++ b/src/components/UserProfile.jsx
@@ -3,6 +3,7 @@ import Skeleton from 'react-loading-skeleton'
 import ProfileImageUploader from './ProfileImageUploader'
 import EditableLabel from './EditableLabel'
 import EditProfileBadge from './EditProfileBadge'
+import Tag from './Tag'
 
 export const UserProfile = ({
   allowEditing,
@@ -113,6 +114,12 @@ export const UserDetails = ({
               {user.Name ? user.Name : user.username}
             </h2>
           </EditableLabel>
+          {!!(
+            user &&
+            user.access_role &&
+            user.access_role.length &&
+            user.access_role[0].name === 'Manager'
+          ) && <Tag content={'Manager'} />}
           <EditableLabel
             type='textArea'
             name={'Bio'}

--- a/src/services/user_story.js
+++ b/src/services/user_story.js
@@ -376,6 +376,9 @@ const userStory = {
           email
           LinkedIn
           Twitter
+          access_role {
+            name
+          }
         }
       }
       `
@@ -401,6 +404,9 @@ const userStory = {
           email
           LinkedIn
           Twitter
+          access_role {
+            name
+          }
         }
       }
       `


### PR DESCRIPTION
**Issue Number**

fixes #269 

**Describe the changes you've made**

I modified the GraphQL query to fetch the role of a user in the MyProfile page. This helps to check if the user is a regular one or a Manager. I have also added a tag component that is rendered to show if the user is a manager, and integrated it into the MyProfile page.

**Describe if there is any unusual behavior (Any Warning) of your code(Write `NA` if there isn't)**

NA

**Additional context (OPTIONAL)**

NA


**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**
![localhost_3000_myProfile](https://user-images.githubusercontent.com/75155230/191354895-8015d7d3-024b-47bf-8ea5-947894065294.png)

Refer to PR #270 for more details