### PR TITLE
Fix #278: Fetching status list dynamically

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,6 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/eos-icons.css' />
-    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css' />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,8 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/eos-icons.css' />
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/eos-icons@latest/dist/css/outlined/eos-icons-outlined.css' />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/assets/scss/components/storyPageTimeline.scss
+++ b/src/assets/scss/components/storyPageTimeline.scss
@@ -55,7 +55,7 @@
   background-color: $eos-white;
 
   .eos-icons {
-    font-size: 1em;
+    font-size: $font-size-general;
     vertical-align: middle;
   }
 }

--- a/src/assets/scss/components/storyPageTimeline.scss
+++ b/src/assets/scss/components/storyPageTimeline.scss
@@ -53,6 +53,11 @@
 
 .storypage-timeline {
   background-color: $eos-white;
+
+  .eos-icons {
+    font-size: 1em;
+    vertical-align: middle;
+  }
 }
 
 .status-icon {

--- a/src/components/StatusContainer.jsx
+++ b/src/components/StatusContainer.jsx
@@ -8,10 +8,10 @@ function StatusContainer(props) {
 
   const filterStories = React.useCallback(() => {
     const filteredStories = props.stories.filter(
-      (story) => story.user_story_status.Status === state.status
+      (story) => story.user_story_status.Status === state.Status
     )
     setStories(filteredStories)
-  }, [props.stories, state.status])
+  }, [props.stories, state.Status])
 
   useEffect(() => {
     filterStories()
@@ -19,8 +19,8 @@ function StatusContainer(props) {
 
   return (
     <div className='status-container'>
-      <h3 className='status'>{state.status}</h3>
-      <Droppable droppableId={state.status} index={props.index}>
+      <h3 className='status'>{state.Status}</h3>
+      <Droppable droppableId={state.Status} index={props.index}>
         {(provided) => (
           <div
             ref={provided.innerRef}

--- a/src/components/Stories.js
+++ b/src/components/Stories.js
@@ -55,6 +55,8 @@ const Stories = ({ authorId, followerId, userId }) => {
 
   const [isDragDisabled, setIsDragDisabled] = useState(true)
 
+  const [statusList, setStatusList] = useState([])
+
   const getPage = useCallback((page) => {
     setPage(page)
   }, [])
@@ -168,6 +170,18 @@ const Stories = ({ authorId, followerId, userId }) => {
     getPermissions()
   }, [userId])
 
+  useEffect(() => {
+    const fetchStatus = async () => {
+      const statusResponse = await userStory.getStatuses()
+      setStatusList([
+        ...Lists.additionalState,
+        ...statusResponse.data.data.userStoryStatuses
+      ])
+    }
+
+    fetchStatus()
+  }, [])
+
   const onDragEnd = async (result) => {
     try {
       if (!result.destination) {
@@ -188,14 +202,13 @@ const Stories = ({ authorId, followerId, userId }) => {
       stories[draggedStoryIndex] = draggedStory
       setStories([...stories])
 
-      const statusResponse = await userStory.getStatuses()
-      const newStatusIndex = statusResponse.data.data.userStoryStatuses
+      const newStatusIndex = statusList
         .map((status) => status.Status)
         .indexOf(result.destination.droppableId)
 
       await userStory.updateUserStoryStatus(
         draggedStory.id,
-        statusResponse.data.data.userStoryStatuses[newStatusIndex].id
+        statusList[newStatusIndex].id
       )
 
       toast.success(`Updated ${draggedStory.Title}`)
@@ -246,13 +259,14 @@ const Stories = ({ authorId, followerId, userId }) => {
             selectState={selectState}
             setPage={setPage}
             currentStateSelected={currentStateSelected}
+            statusList={statusList}
           />
         )}
       </div>
       <div className='status-container-box flex'>
         <DragDropContext onDragEnd={onDragEnd}>
           {isRoadmapView &&
-            Lists.stateList
+            statusList
               .slice(1)
               .map((state, index) => (
                 <StatusContainer
@@ -267,7 +281,11 @@ const Stories = ({ authorId, followerId, userId }) => {
       </div>
       {!isRoadmapView && (
         <div className='stories-div'>
-          <StoriesList stories={stories} isLoading={promiseInProgress} />
+          <StoriesList
+            stories={stories}
+            isLoading={promiseInProgress}
+            statusList={statusList}
+          />
         </div>
       )}
       {!isRoadmapView && (

--- a/src/components/StoryPageTimeline.js
+++ b/src/components/StoryPageTimeline.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import Modal from './Modal'
 import { Link } from '@reach/router'
 import userStory from '../services/user_story'
-import Lists from '../utils/Lists'
 import { EOS_THUMB_UP } from 'eos-icons-react'
 import { Stepper, Step, StepTitle } from 'react-custom-stepper'
 
@@ -52,15 +51,21 @@ const StoryPageTimeline = (props) => {
 
   const [step, setStep] = useState(0)
 
+  const [statusList, setStatusList] = useState([])
+
   const togglePopup = () => {
     setIsOpen(!isOpen)
   }
 
   useEffect(() => {
-    const setStatuses = () => {
-      for (let i = 0; i < Lists.stateList.length; i++) {
-        if (Lists.stateList[i].status === currentStatus) {
-          setStep(i - 1)
+    const setStatuses = async () => {
+      const statusResponse = await userStory.getStatuses()
+      const _statusList = statusResponse.data.data.userStoryStatuses
+      setStatusList(_statusList)
+
+      for (let i = 0; i < _statusList.length; i++) {
+        if (_statusList[i].Status === currentStatus) {
+          setStep(i)
           break
         }
       }
@@ -188,9 +193,12 @@ const StoryPageTimeline = (props) => {
       </div>
       <div className='storypage-timeline'>
         <Stepper vertical step={step} theme={stepperTheme}>
-          {Lists.stateList.slice(1).map((ele, key) => (
-            <Step customContent={() => ele.icon} key={key}>
-              <StepTitle>{ele.status}</StepTitle>
+          {statusList.map((ele, key) => (
+            <Step
+              customContent={() => <i className='eos-icons'>{ele.icon_name}</i>}
+              key={key}
+            >
+              <StepTitle>{ele.Status}</StepTitle>
             </Step>
           ))}
         </Stepper>

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,18 +1,26 @@
 import React, { useEffect, useState } from 'react'
 import { EOS_CHECK } from 'eos-icons-react'
-
-import Lists from '../utils/Lists'
+import userStory from '../services/user_story'
 
 const Timeline = (props) => {
   const { currentStatus } = props
 
   const [previousStatuses, setPreviousStatuses] = useState([])
+
+  const [statusList, setStatusList] = useState([])
+
   useEffect(() => {
-    const setStatuses = () => {
+    const setStatuses = async () => {
+
+      const statusResponse = userStory.getStatuses()
+      const _statusList = statusResponse.data.data.userStoryStatuses
+
+      setStatusList(_statusList)
+
       const tempList = []
-      for (let i = 0; i < Lists.stateList.length; i++) {
-        tempList.push(Lists.stateList[i].status)
-        if (Lists.stateList[i].status === currentStatus) break
+      for (let i = 0; i < _statusList.length; i++) {
+        tempList.push(_statusList[i].status)
+        if (_statusList[i].status === currentStatus) break
       }
 
       setPreviousStatuses(tempList)
@@ -22,7 +30,7 @@ const Timeline = (props) => {
 
   return (
     <div className='flex flex-row flex-space-around status-wrapper'>
-      {Lists.stateList.map((ele, key) => {
+      {statusList.map((ele, key) => {
         return (
           <div className='status-element' key={key}>
             <div className='status flex flex-column'>

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -11,7 +11,6 @@ const Timeline = (props) => {
 
   useEffect(() => {
     const setStatuses = async () => {
-
       const statusResponse = userStory.getStatuses()
       const _statusList = statusResponse.data.data.userStoryStatuses
 

--- a/src/components/roadmap-filter.js
+++ b/src/components/roadmap-filter.js
@@ -1,13 +1,12 @@
 import React, { useState, useRef } from 'react'
 import Dropdown from './Dropdown'
-import Lists from '../utils/Lists'
 
 const RoadmapFilter = (props) => {
   const { selectState, setPage } = props
   const [status, setStatus] = useState('All')
   const statusDropdownContainer = useRef()
 
-  const statusOptions = [...Lists.stateList].reduce(
+  const statusOptions = [...props.statusList].reduce(
     (acc, cur) => [...acc, cur.status],
     []
   )

--- a/src/pages/Story.js
+++ b/src/pages/Story.js
@@ -30,7 +30,6 @@ import Modal from '../components/Modal'
 import userStory from '../services/user_story'
 import SimilarStories from '../components/SimilarStories'
 import Dropdown from '../components/Dropdown'
-import Lists from '../utils/Lists'
 
 const Story = (props) => {
   const { storyId } = props
@@ -57,11 +56,13 @@ const Story = (props) => {
 
   const [openDeleteModal, setOpenDeleteModal] = useState(false)
 
-  const [currentStatus, setCurrentStatus] = useState(Lists.stateList[0].status)
+  const [currentStatus, setCurrentStatus] = useState('All')
 
   const [updateStatus, setUpdateStatus] = useState(false)
 
   const [isUpdateAllowed, setIsUpdateAllowed] = useState(false)
+
+  const [statusList, setStatusList] = useState([])
 
   const togglePopup = () => {
     setIsOpen(!isOpen)
@@ -118,6 +119,15 @@ const Story = (props) => {
       getPermissions()
     }
   }, [storyId, userId])
+
+  useEffect(() => {
+    const fetchStatuses = async () => {
+      const statusResponse = await userStory.getStatuses()
+      setStatusList(statusResponse.data.data.userStoryStatuses)
+    }
+
+    fetchStatuses()
+  }, [])
 
   const save = async (event) => {
     if (editDescription.length <= 0) {
@@ -407,9 +417,7 @@ const Story = (props) => {
                       <Dropdown
                         curr={currentStatus}
                         setCurr={setCurrentStatus}
-                        itemList={Lists.stateList
-                          .slice(1)
-                          .map((state) => state.status)}
+                        itemList={statusList.map((state) => state.Status)}
                         reference={storyContainer}
                       />
                       <span>

--- a/src/services/user_story.js
+++ b/src/services/user_story.js
@@ -270,6 +270,7 @@ const userStory = {
         userStoryStatuses {
           id
           Status
+          icon_name
         }
       }`
     }

--- a/src/utils/Lists.js
+++ b/src/utils/Lists.js
@@ -1,43 +1,8 @@
-import React from 'react'
-import {
-  EOS_ALL_INCLUSIVE,
-  EOS_SCHEDULE,
-  EOS_CHECK_CIRCLE,
-  EOS_MODE_EDIT,
-  EOS_CODE,
-  EOS_PATCH_FIXES,
-  EOS_DEPLOY
-} from 'eos-icons-react'
-
 const Lists = {
-  stateList: [
+  additionalState: [
     {
-      icon: <EOS_ALL_INCLUSIVE className='eos-icons' />,
-      status: 'All'
-    },
-    {
-      icon: <EOS_SCHEDULE className='eos-icons' />,
-      status: 'Under consideration'
-    },
-    {
-      icon: <EOS_CHECK_CIRCLE className='eos-icons' />,
-      status: 'Planned'
-    },
-    {
-      icon: <EOS_MODE_EDIT className='eos-icons' />,
-      status: 'Designing'
-    },
-    {
-      icon: <EOS_CODE className='eos-icons' />,
-      status: 'Implementing'
-    },
-    {
-      icon: <EOS_PATCH_FIXES className='eos-icons' />,
-      status: 'Testing'
-    },
-    {
-      icon: <EOS_DEPLOY className='eos-icons' />,
-      status: 'Deployed'
+      status: 'All',
+      icon_name: 'all_inclusive'
     }
   ],
   sortByList: ['Most Voted', 'Most Discussed']


### PR DESCRIPTION
**Issue Number**

fixes #278 

<!-- Please Mention the issue number as ISSUE #(Issue Number)
Example:
fixes #1
-->

**Describe the changes you've made**

I have removed the hardcoded status list from the `./src/utils/Lists` directory and shifted to fetching the status list dynamically from the strapi. In each of the modified components, I have fetched the status list using `getStatuses` service and then updated the `statusList` state within a `useEffect` hook. I have also updated the same service to fetch the icon name that is associated with that status.

**Describe if there is any unusual behavior (Any Warning) of your code(Write `NA` if there isn't)**

NA

**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**

NA
